### PR TITLE
Improve Chinese side of auto language detection

### DIFF
--- a/source/languageDetection.py
+++ b/source/languageDetection.py
@@ -90,7 +90,7 @@ langIDToScriptID = OrderedDict([
 	("sr" , ("Latin" , "Cyrillic" , "Number" ) ),
 	("ja" , ("Han", "Hiragana", "Katakana", "FullWidthNumber" , "Number" ) ), 
 	("ko" , ("Han", "Hiragana", "Katakana", "Hangul" , "FullWidthNumber" , "Number" ) ), 
-	("zh" , ("Han", "Hiragana", "Katakana", "FullWidthNumber"  , "Number" ) ), 
+	("zh" , ("Han", "FullWidthNumber"  , "Number" ) ), 
 ])
 
 def getLanguagesWithDescriptions(ignoreLanguages=None):


### PR DESCRIPTION
### Link to issue number:
nvaccess/nvda#2990
### Summary of the issue:

### Description of how this pull request fixes the issue:
There is no Hiragana or Katagana in Chinese

### Testing performed:

### Known issues with pull request:
n/a
### Change log entry:
n/a